### PR TITLE
Updated shellcheck binary URL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN git --version \
 # Install shellcheck
 # @see https://github.com/koalaman/shellcheck/releases
 ENV SHELLCHECK_VERSION=0.7.0
-RUN curl -L -o "/tmp/shellcheck-v${SHELLCHECK_VERSION}.tar.xz" "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+RUN curl -L -o "/tmp/shellcheck-v${SHELLCHECK_VERSION}.tar.xz" "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
   && tar --xz -xvf "/tmp/shellcheck-v${SHELLCHECK_VERSION}.tar.xz" \
   && mv "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/bin/ \
   && shellcheck --version


### PR DESCRIPTION
This docker build has been failing with this error message:

```
You are downloading ShellCheck from an outdated URL!

Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/v0.7.0/shellcheck-v0.7.0.linux.x86_64.tar.xz

For more information, see:
https://github.com/koalaman/shellcheck/issues/1871

PS: Sorry for breaking your build. The hosting costs were getting out of hand :(
```

This fixes the issue by updating the source URL for `shellcheck`.