### PR TITLE
Set /tmp as a volume to avoid temp files being committed to layers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM php:7.2-cli
 LABEL Maintainer="Alex Skrypnyk <alex@integratedexperts.com>"
 
+# Ensure temporary files are not retained in image.
+VOLUME /tmp
+
 # Install git and ssh.
 RUN apt-get update -qq \
     && apt-get install -y git ssh lsof zip unzip vim lynx curl aspell-en jq


### PR DESCRIPTION
Currently temporary files used for installing stuff in the image leaves cruft in `/tmp`

```
ls -l /tmp
total 63328
-rw-r--r-- 1 root root    38968 Jan 10  2020 bats.tar.gz
drwxrwxr-x 2 1000 1000     4096 Jan 10  2020 docker
-rw-r--r-- 1 root root 63252595 Jan 10  2020 docker-19.03.5.tgz
-rw-r--r-- 1 root root  1545588 Jan 10  2020 shellcheck-v0.7.0.tar.xz
```

This PR sets `/tmp` to a volume so these files are not committed to image layers.