### PR TITLE
Added 'update-deps' skill and updated 'moby/docker' to 29.5.2.

### DIFF
--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -1,28 +1,20 @@
 ---
 name: update-deps
-description: Update all renovate-annotated dependency versions in the Dockerfile by querying upstream for each latest release, edit the pinned versions in place, commit, then hand off to /open-pr. Use when the user asks to "update deps", "bump deps", "update dockerfile deps", or refresh image dependencies on-demand (out-of-band from Renovate).
+description: Check the latest upstream version for every renovate-annotated dependency in the Dockerfile, then rewrite the pinned version literals in place. Use when the user asks to "update deps", "bump deps", "update dockerfile deps", or refresh image dependencies. Git operations are out of scope.
 ---
 
 # Update Dockerfile dependencies
 
-On-demand bumping of every pinned version in `Dockerfile`. Mirrors what Renovate would eventually produce, but interactive and immediate.
+Scan `Dockerfile`, resolve each renovate-annotated dependency's latest upstream version, and rewrite the pinned `version=...` literal in place. The skill stops after the file edits. Branching, committing, and PR creation are not part of this skill.
 
 ## When to use
 
 - User asks to update deps, bump deps, update dockerfile deps, or refresh image dependencies.
-- A specific tool needs to be bumped right now and waiting for Renovate is not acceptable.
 
 ## When NOT to use
 
 - Updating Drupal / Composer / Vortex packages. Use the dedicated `/update-drupal`, `/update-vortex`, or Composer-related skills.
 - Editing `versions-config.json` or `goss.yaml`. Both track runtime detection; neither pins versions.
-- The user wants README package versions refreshed. That happens automatically via `.github/workflows/update-readme.yml` after merge.
-
-## Pre-flight
-
-1. Confirm clean working tree: `git status --porcelain` must be empty.
-2. Confirm branch. If on `main`, `master`, or `develop`, create `feature/update-deps-YYMMDD` (today's date, e.g. `feature/update-deps-260521`).
-3. Confirm these CLIs are on `$PATH`: `gh`, `jq`, `npm`, `curl`, `docker`. If any are missing, stop and ask the user how to proceed.
 
 ## Step 1 - Discover entries
 
@@ -32,85 +24,71 @@ Read `Dockerfile`. Find every block matching the Renovate custom-manager regex f
 #\s*renovate:\s*datasource=(?<datasource>\S+)\s+depName=(?<depName>\S+)(?:\s+versioning=(?<versioning>\S+))?(?:\s+extractVersion=(?<extractVersion>\S+))?\s*\n(?:.*\n)*?.*?(?:ENV|ARG|RUN)\s+.*?version=(?<currentValue>[^\s&]+)
 ```
 
-For each match, record:
+For each match, record `{datasource, depName, versioning, extractVersion, currentValue, lineNumber}`.
 
-- `datasource`
-- `depName`
-- `versioning` (optional)
-- `extractVersion` (optional)
-- `currentValue`
-- `lineNumber` of the `version=` literal (this is the line you will edit)
-
-Also capture the base image digest pin from the `FROM` line:
+Also capture the base image digest pin from the two `FROM` lines (builder + final):
 
 - Pattern: `FROM php:8.4-cli-bookworm@sha256:<digest>`
-- This is a `docker` datasource entry. There are two `FROM` lines (builder + final). Both must be updated to the same new digest.
+- Datasource is `docker`. Both `FROM` lines must end up with the same new digest.
 
 ## Step 2 - Resolve latest per datasource
 
-Make one Bash call per command (no piping, no `&&` chaining). Save intermediate output to files under `.artifacts/tmp/` if you need to process it further with `jq` or similar.
+Make one Bash call per command. Do not chain with `&&`, do not pipe with `|`; the global hook blocks both. If a step needs JSON processing, save the response to `.artifacts/tmp/` first, then run `jq` against the file in a separate call.
+
+If any single resolver fails, record the dep as `error` and continue. Do not abort the whole run.
 
 ### `github-releases`
 
-1. `gh api repos/<depName>/releases/latest --jq .tag_name` returns e.g. `v0.11.0` or `43`.
-2. Strip a leading `v` if present, since the Dockerfile stores the bare value.
-3. If `extractVersion` is something other than `^(?<version>.*)$`, apply the regex literally to the tag name.
-4. If `gh` is unauthenticated and rate-limited, fall back to `curl -fsSL https://api.github.com/repos/<depName>/releases/latest -o .artifacts/tmp/<depName>.json` and parse `.tag_name` with `jq`.
+1. `gh api repos/<depName>/releases/latest --jq .tag_name` returns e.g. `v0.11.0`, `43`, or `docker-v29.5.2`.
+2. If the API returns 404 (no releases published, only tags), fall back to `gh api repos/<depName>/tags --jq ".[0].name"`.
+3. Normalize the tag to a bare version: strip any leading `v` and any non-semver prefix such as `docker-v` (moby/moby uses this).
+4. If `extractVersion` is something other than `^(?<version>.*)$`, apply that regex literally to the tag instead.
 
 ### `npm`
 
-1. `npm view <depName> version` returns the latest semver string. No `v` prefix.
+1. `npm view <depName> version` returns the latest semver, no prefix.
 
 ### `node` (with `versioning=node`)
 
 1. `curl -fsSL https://nodejs.org/dist/index.json -o .artifacts/tmp/node-index.json`
-2. `jq -r '[.[] | select(.lts != false)][0].version' .artifacts/tmp/node-index.json` returns the latest LTS, e.g. `v24.15.0`.
-3. Strip the leading `v` per `extractVersion=^v(?<version>.*)$`.
+2. `jq -r 'map(select(.lts != false))[0].version' .artifacts/tmp/node-index.json` returns the latest LTS, e.g. `v24.15.0`. The filter is intentionally pipe-free.
+3. Strip the leading `v`.
 
 ### `docker` (base image)
 
-1. `docker buildx imagetools inspect php:8.4-cli-bookworm --format "{{.Manifest.Digest}}"` returns `sha256:<digest>`.
-2. If `buildx` is unavailable, fall back to:
-   - `docker pull php:8.4-cli-bookworm`
-   - `docker inspect --format "{{index .RepoDigests 0}}" php:8.4-cli-bookworm` and strip the `php@` prefix to get `sha256:<digest>`.
-
-If any resolver fails for a single dependency, record it as `error` in the diff table and continue with the others. Do not abort the whole run on a single resolver failure.
+1. `docker buildx imagetools inspect php:8.4-cli-bookworm --raw` prints the raw index JSON to stdout; redirect with `> .artifacts/tmp/php-index.json` is fine because it is a redirection, not a pipe.
+2. `jq -r ".manifests[0].digest" .artifacts/tmp/php-index.json` is one option, but the value the Dockerfile pins is the index digest, not a per-arch manifest digest. The simplest reliable command is `docker manifest inspect --verbose php:8.4-cli-bookworm` and read the top-level `Digest` field for the named tag.
+3. Fallback: `docker pull php:8.4-cli-bookworm`, then `docker inspect --format "{{index .RepoDigests 0}}" php:8.4-cli-bookworm`, then strip the `php@` prefix.
 
 ## Step 3 - Print the diff
 
-Render a markdown table to the chat so the user can see what is about to change:
+Render a markdown table so the user sees exactly what will change:
 
 ```
 | Dependency      | Datasource      | Current   | Latest    | Status     |
 |-----------------|-----------------|-----------|-----------|------------|
-| kcov            | github-releases | 43        | 44        | bump       |
-| shellcheck      | github-releases | 0.11.0    | 0.11.0    | up-to-date |
+| kcov            | github-releases | 43        | 43        | up-to-date |
+| docker (moby)   | github-releases | 28.5.2    | 29.5.2    | bump       |
 | php (base)      | docker          | sha256:ca | sha256:7f | bump       |
 ```
 
-If there is nothing to bump, stop here, report "All dependencies are up to date.", and do not commit or push.
+If nothing is behind, stop here and report "All dependencies are up to date.". Do not touch `Dockerfile`.
 
-## Step 4 - Apply edits
+## Step 4 - Edit the Dockerfile
 
 For every `bump` row, use the `Edit` tool on `Dockerfile`:
 
-- Include enough surrounding context in `old_string` so the replacement is unambiguous. Anchoring on the preceding `# renovate:` comment line is the safest pattern when `version=<value>` is not unique across the file.
-- Replace only the `<value>` after `version=`. Do not reformat other lines.
+- Include the preceding `# renovate: ...` comment line in `old_string` so the replacement is unambiguous when `version=<value>` is not unique on its own.
+- Replace only the `<value>` after `version=`. Do not reformat surrounding lines.
 
-For the base image bump, replace the `@sha256:<old>` digest across both `FROM` lines. Use `replace_all: true` since the digest substring is unique to the base image.
+For the base image bump, replace the `@sha256:<old>` substring with `@sha256:<new>` using `replace_all: true` (the digest substring is unique to the base image, so this safely covers both `FROM` lines).
 
-After every edit, re-read the affected lines to confirm the change landed correctly.
+After each edit, re-read the affected line to confirm the change landed correctly.
 
-## Step 5 - Commit and hand off
-
-1. `git add Dockerfile`
-2. `git commit -m "Updated Docker image dependencies."`
-3. Invoke the `/open-pr` skill. Never call `gh pr create` directly.
+The skill ends here. Do not stage, commit, or push.
 
 ## Notes
 
-- `goss.yaml` asserts presence and output of commands, not numeric versions, so it does not need updates here.
-- `versions-config.json` is consumed by `versions.js` for README rendering. Leave it alone.
-- The README "Included packages" section is regenerated post-merge by `.github/workflows/update-readme.yml`.
-- Yarn is intentionally pinned to v1.x (classic). `npm view yarn version` returns the latest 1.x because Yarn Berry is published as `@yarnpkg/cli`, not `yarn`.
-- Verification is intentionally not part of this skill. CI (`.github/workflows/test.yml`) builds the image and runs `dgoss` on the PR.
+- `goss.yaml` and `versions-config.json` do not pin versions and are not touched.
+- README's "Included packages" section is regenerated post-merge by `.github/workflows/update-readme.yml`.
+- Yarn is intentionally pinned to v1.x (classic). `npm view yarn version` returns the latest 1.x; Yarn Berry is published as `@yarnpkg/cli`.

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -20,7 +20,7 @@ Scan `Dockerfile`, resolve each renovate-annotated dependency's latest upstream 
 
 Read `Dockerfile`. Find every block matching the Renovate custom-manager regex from `renovate.json`:
 
-```
+```regex
 #\s*renovate:\s*datasource=(?<datasource>\S+)\s+depName=(?<depName>\S+)(?:\s+versioning=(?<versioning>\S+))?(?:\s+extractVersion=(?<extractVersion>\S+))?\s*\n(?:.*\n)*?.*?(?:ENV|ARG|RUN)\s+.*?version=(?<currentValue>[^\s&]+)
 ```
 
@@ -64,7 +64,7 @@ If any single resolver fails, record the dep as `error` and continue. Do not abo
 
 Render a markdown table so the user sees exactly what will change:
 
-```
+```markdown
 | Dependency      | Datasource      | Current   | Latest    | Status     |
 |-----------------|-----------------|-----------|-----------|------------|
 | kcov            | github-releases | 43        | 43        | up-to-date |

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: update-deps
+description: Update all renovate-annotated dependency versions in the Dockerfile by querying upstream for each latest release, edit the pinned versions in place, commit, then hand off to /open-pr. Use when the user asks to "update deps", "bump deps", "update dockerfile deps", or refresh image dependencies on-demand (out-of-band from Renovate).
+---
+
+# Update Dockerfile dependencies
+
+On-demand bumping of every pinned version in `Dockerfile`. Mirrors what Renovate would eventually produce, but interactive and immediate.
+
+## When to use
+
+- User asks to update deps, bump deps, update dockerfile deps, or refresh image dependencies.
+- A specific tool needs to be bumped right now and waiting for Renovate is not acceptable.
+
+## When NOT to use
+
+- Updating Drupal / Composer / Vortex packages. Use the dedicated `/update-drupal`, `/update-vortex`, or Composer-related skills.
+- Editing `versions-config.json` or `goss.yaml`. Both track runtime detection; neither pins versions.
+- The user wants README package versions refreshed. That happens automatically via `.github/workflows/update-readme.yml` after merge.
+
+## Pre-flight
+
+1. Confirm clean working tree: `git status --porcelain` must be empty.
+2. Confirm branch. If on `main`, `master`, or `develop`, create `feature/update-deps-YYMMDD` (today's date, e.g. `feature/update-deps-260521`).
+3. Confirm these CLIs are on `$PATH`: `gh`, `jq`, `npm`, `curl`, `docker`. If any are missing, stop and ask the user how to proceed.
+
+## Step 1 - Discover entries
+
+Read `Dockerfile`. Find every block matching the Renovate custom-manager regex from `renovate.json`:
+
+```
+#\s*renovate:\s*datasource=(?<datasource>\S+)\s+depName=(?<depName>\S+)(?:\s+versioning=(?<versioning>\S+))?(?:\s+extractVersion=(?<extractVersion>\S+))?\s*\n(?:.*\n)*?.*?(?:ENV|ARG|RUN)\s+.*?version=(?<currentValue>[^\s&]+)
+```
+
+For each match, record:
+
+- `datasource`
+- `depName`
+- `versioning` (optional)
+- `extractVersion` (optional)
+- `currentValue`
+- `lineNumber` of the `version=` literal (this is the line you will edit)
+
+Also capture the base image digest pin from the `FROM` line:
+
+- Pattern: `FROM php:8.4-cli-bookworm@sha256:<digest>`
+- This is a `docker` datasource entry. There are two `FROM` lines (builder + final). Both must be updated to the same new digest.
+
+## Step 2 - Resolve latest per datasource
+
+Make one Bash call per command (no piping, no `&&` chaining). Save intermediate output to files under `.artifacts/tmp/` if you need to process it further with `jq` or similar.
+
+### `github-releases`
+
+1. `gh api repos/<depName>/releases/latest --jq .tag_name` returns e.g. `v0.11.0` or `43`.
+2. Strip a leading `v` if present, since the Dockerfile stores the bare value.
+3. If `extractVersion` is something other than `^(?<version>.*)$`, apply the regex literally to the tag name.
+4. If `gh` is unauthenticated and rate-limited, fall back to `curl -fsSL https://api.github.com/repos/<depName>/releases/latest -o .artifacts/tmp/<depName>.json` and parse `.tag_name` with `jq`.
+
+### `npm`
+
+1. `npm view <depName> version` returns the latest semver string. No `v` prefix.
+
+### `node` (with `versioning=node`)
+
+1. `curl -fsSL https://nodejs.org/dist/index.json -o .artifacts/tmp/node-index.json`
+2. `jq -r '[.[] | select(.lts != false)][0].version' .artifacts/tmp/node-index.json` returns the latest LTS, e.g. `v24.15.0`.
+3. Strip the leading `v` per `extractVersion=^v(?<version>.*)$`.
+
+### `docker` (base image)
+
+1. `docker buildx imagetools inspect php:8.4-cli-bookworm --format "{{.Manifest.Digest}}"` returns `sha256:<digest>`.
+2. If `buildx` is unavailable, fall back to:
+   - `docker pull php:8.4-cli-bookworm`
+   - `docker inspect --format "{{index .RepoDigests 0}}" php:8.4-cli-bookworm` and strip the `php@` prefix to get `sha256:<digest>`.
+
+If any resolver fails for a single dependency, record it as `error` in the diff table and continue with the others. Do not abort the whole run on a single resolver failure.
+
+## Step 3 - Print the diff
+
+Render a markdown table to the chat so the user can see what is about to change:
+
+```
+| Dependency      | Datasource      | Current   | Latest    | Status     |
+|-----------------|-----------------|-----------|-----------|------------|
+| kcov            | github-releases | 43        | 44        | bump       |
+| shellcheck      | github-releases | 0.11.0    | 0.11.0    | up-to-date |
+| php (base)      | docker          | sha256:ca | sha256:7f | bump       |
+```
+
+If there is nothing to bump, stop here, report "All dependencies are up to date.", and do not commit or push.
+
+## Step 4 - Apply edits
+
+For every `bump` row, use the `Edit` tool on `Dockerfile`:
+
+- Include enough surrounding context in `old_string` so the replacement is unambiguous. Anchoring on the preceding `# renovate:` comment line is the safest pattern when `version=<value>` is not unique across the file.
+- Replace only the `<value>` after `version=`. Do not reformat other lines.
+
+For the base image bump, replace the `@sha256:<old>` digest across both `FROM` lines. Use `replace_all: true` since the digest substring is unique to the base image.
+
+After every edit, re-read the affected lines to confirm the change landed correctly.
+
+## Step 5 - Commit and hand off
+
+1. `git add Dockerfile`
+2. `git commit -m "Updated Docker image dependencies."`
+3. Invoke the `/open-pr` skill. Never call `gh pr create` directly.
+
+## Notes
+
+- `goss.yaml` asserts presence and output of commands, not numeric versions, so it does not need updates here.
+- `versions-config.json` is consumed by `versions.js` for README rendering. Leave it alone.
+- The README "Included packages" section is regenerated post-merge by `.github/workflows/update-readme.yml`.
+- Yarn is intentionally pinned to v1.x (classic). `npm view yarn version` returns the latest 1.x because Yarn Berry is published as `@yarnpkg/cli`, not `yarn`.
+- Verification is intentionally not part of this skill. CI (`.github/workflows/test.yml`) builds the image and runs `dgoss` on the PR.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+!.claude
+!.claude/skills
+!.claude/skills/*
+.claude/settings.local.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,7 @@ RUN version=1.13.0 && \
 # Install Docker.
 # @see https://download.docker.com/linux/static/stable/x86_64
 # renovate: datasource=github-releases depName=moby/moby extractVersion=^(?<version>.*)$
-RUN version=28.5.2 && \
+RUN version=29.5.2 && \
     curl -L -o "/tmp/docker-${version}.tgz" "https://download.docker.com/linux/static/stable/x86_64/docker-${version}.tgz" && \
     tar -xz -C /tmp -f "/tmp/docker-${version}.tgz" && \
     mv /tmp/docker/* /usr/bin && \


### PR DESCRIPTION
## Summary

Adds a project-scoped Claude skill (`update-deps`) that automates Dockerfile dependency version bumping. The skill scans `Dockerfile` for Renovate-annotated entries, resolves each dependency's latest upstream version via its datasource (GitHub releases, npm, Node.js LTS, or Docker Hub), prints a diff table, and edits the pinned `version=...` literals in place. Git operations (branching, committing, pushing) are explicitly out of scope and left to the caller.

Also includes the first use of the skill: bumping `moby/docker` from `28.5.2` to `29.5.2` (a major version bump - upstream tag `docker-v29.5.2`).

## Changes

### `.claude/skills/update-deps/SKILL.md` (new)

- Defines the `update-deps` skill with four sections: dependency discovery, per-datasource version resolution, diff table rendering, and in-place `Dockerfile` editing.
- Documents supported datasources: `github-releases`, `npm`, `node` (LTS), and `docker` (base image digest).
- Includes per-datasource fallback logic (e.g. tags when no releases exist, `docker pull` fallback for digest resolution).
- Instructs the model to stop after file edits and not touch `goss.yaml`, `versions-config.json`, or README.

### `.gitignore` (new)

- Adds entries to allow `.claude/skills/` to be tracked while keeping `settings.local.json` ignored.

### `Dockerfile`

- Bumps `moby/docker` (`moby/moby` on GitHub) from `28.5.2` to `29.5.2` in the pinned `version=` literal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new skill specification for updating Dockerfile dependency version pins and base image digests.

* **Chores**
  * Updated the installed Docker engine version from 28.5.2 to 29.5.2.
  * Updated ignore rules to exclude local tool/runtime metadata and settings files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/ci-runner/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->