### PR TITLE
Fixed 'README.md' inconsistencies and corrected 'versions.js' newline accumulation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Based on Debian `php:8.4-cli-bookworm`.
 - [kcov](https://github.com/SimonKagstrom/kcov): `43`
 - [lsof](https://github.com/lsof-org/lsof): `4.95.0`
 - [Lynx](https://lynx.invisible-island.net): `2.9.0`
-- [Node.js](https://nodejs.org): `24.16.0`
-- [npm](https://www.npmjs.com): `11.13.0`
-- [npx](https://www.npmjs.com/package/npx): `11.13.0`
+- [Node.js](https://nodejs.org): `24.15.0`
+- [npm](https://www.npmjs.com): `11.12.1`
+- [npx](https://www.npmjs.com/package/npx): `11.12.1`
 - [PHP](https://www.php.net): `8.4.21`
 - [rsync](https://rsync.samba.org): `3.2.7`
 - [ShellCheck](https://www.shellcheck.net): `0.11.0`
@@ -53,23 +53,24 @@ Based on Debian `php:8.4-cli-bookworm`.
 - [Vim](https://www.vim.org): `9.0`
 - [Yarn](https://yarnpkg.com): `1.22.22`
 - [Zip](http://www.info-zip.org/Zip.html): `3.0`
+
 ## Usage
 
 Make sure to **always** pin the version of this image to the tag:
 
-```
-drevops/ci-runner:25.1.0
+```text
+drevops/ci-runner:25.8.0
 ```
 
 For testing purposes, you can use the `canary` tag:
 
-```
+```text
 drevops/ci-runner:canary
 ```
 
 When using in GitHub Actions, make sure to add a fix for the overwritten `$HOME`:
 
-```
+```yaml
 name: Test
 
 jobs:
@@ -89,7 +90,7 @@ jobs:
 
 ## Testing
 
-The image includes [Goss](https://github.com/aelsabbahy/goss) for environment testing. To run tests locally using dgoss:
+This project uses [Goss](https://github.com/aelsabbahy/goss) (via `dgoss`) to test the image environment from the host. The image itself does not bundle Goss. To run the tests locally:
 
 ```bash
 # Build the image
@@ -128,11 +129,11 @@ export GOSS_PATH=~/bin/goss-linux-amd64
 
 This project uses _Year-Month-Patch_ versioning:
 
-- `YY`: Last two digits of the year, e.g., `23` for 2023.
+- `YY`: Last two digits of the year, e.g., `25` for 2025.
 - `m`: Numeric month, e.g., April is `4`.
 - `patch`: Patch number for the month, starting at `0`.
 
-Example: `23.4.2` indicates the third patch in April 2023.
+Example: `25.4.2` indicates the third patch in April 2025.
 
 ### Releasing
 
@@ -152,137 +153,3 @@ a `canary` version.
 
 ---
 _This repository was created using the [Scaffold](https://getscaffold.dev/) project template_
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Based on Debian `php:8.4-cli-bookworm`.
 - [kcov](https://github.com/SimonKagstrom/kcov): `43`
 - [lsof](https://github.com/lsof-org/lsof): `4.95.0`
 - [Lynx](https://lynx.invisible-island.net): `2.9.0`
-- [Node.js](https://nodejs.org): `24.15.0`
-- [npm](https://www.npmjs.com): `11.12.1`
-- [npx](https://www.npmjs.com/package/npx): `11.12.1`
+- [Node.js](https://nodejs.org): `24.16.0`
+- [npm](https://www.npmjs.com): `11.13.0`
+- [npx](https://www.npmjs.com/package/npx): `11.13.0`
 - [PHP](https://www.php.net): `8.4.21`
 - [rsync](https://rsync.samba.org): `3.2.7`
 - [ShellCheck](https://www.shellcheck.net): `0.11.0`

--- a/versions.js
+++ b/versions.js
@@ -50,6 +50,7 @@ function updateReadme(readmePath, sectionTitle, newContent) {
   for (const line of lines) {
     if (line === sectionTitle) {
       result.push(newContent.trimEnd());
+      result.push('');
       shouldSkip = true;
       continue;
     }
@@ -63,7 +64,7 @@ function updateReadme(readmePath, sectionTitle, newContent) {
     }
   }
 
-  const newReadme = result.join('\n') + "\n\n";
+  const newReadme = result.join('\n').replace(/\n*$/, '\n');
 
   if (readme === newReadme) {
     return false;


### PR DESCRIPTION
## Summary

`README.md` contained several factual errors and formatting inconsistencies that had accumulated over time. A root cause was a bug in `versions.js`: each automated update run appended extra trailing newlines and dropped the blank line between the generated packages section and the next heading. Over many runs this caused ~130 trailing blank lines to accumulate. This PR corrects both the README content directly and patches the script so the rot cannot recur.

## Changes

### `README.md`

- Corrected the Testing section: the image does not bundle Goss; Goss runs from the host via `dgoss` against the built image. The previous wording was factually wrong.
- Unified the two `drevops/ci-runner:<tag>` usage examples to the same version (`25.8.0`); the plain Usage snippet was lagging behind the GitHub Actions snippet.
- Added language identifiers (`text`, `yaml`) to three fenced code blocks (markdownlint MD040).
- Added the missing blank line before `## Usage`.
- Bumped the year example in the Versioning section from 2023 to 2025.
- Removed ~130 accumulated trailing blank lines, leaving a single trailing newline.

### `versions.js`

- After writing the replaced section content, the script now pushes an explicit blank-line separator before the next `## ` heading. Previously the skip-loop consumed the original blank line without replacing it, so every regenerated README had no separation between sections.
- Replaced `result.join('\n') + "\n\n"` with `result.join('\n').replace(/\n*$/, '\n')`. The old code unconditionally appended two newlines on every run; combined with split/join semantics on a newline-terminated file, this added two trailing blank lines per regeneration cycle - the source of the ~130 line accumulation.

## Note on commit history

The branch has three commits. Commit 2 (`Restored 'Node.js', 'npm', 'npx' versions in 'README.md'.`) walks back a version regression accidentally introduced in commit 1. The net diff for `Node.js`, `npm`, and `npx` versions across the PR is zero - those three packages are untouched in the final state. The intermediate commit is noise and can be ignored during review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated usage instructions with latest image tag (25.8.0)
* Clarified Goss testing procedures in documentation
* Updated versioning examples to 2025 format

## Chores
* Enhanced README generation formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drevops/ci-runner/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->